### PR TITLE
Pass the options used to connect through to the monitor

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -108,7 +108,7 @@ defmodule Mongo do
   end
 
   def child_spec(opts, child_opts \\ []) do
-    Supervisor.Spec.worker(Mongo.Topology, [opts], child_opts)
+    Supervisor.Spec.worker(Mongo, [opts], child_opts)
   end
 
   @doc """


### PR DESCRIPTION
This will allow the monitor to call the `Mongo.direct_command/3` function. This
is specifically important when using a `:pool` that is not the default.